### PR TITLE
add trace header

### DIFF
--- a/src/upstage_mcp/document_parser.py
+++ b/src/upstage_mcp/document_parser.py
@@ -73,7 +73,10 @@ async def parse_document_api(
     try:
         # Initialize API client with timeout
         async with httpx.AsyncClient(timeout=httpx.Timeout(REQUEST_TIMEOUT)) as client:
-            headers = {"Authorization": f"Bearer {api_key}"}
+            headers = {
+                "Authorization": f"Bearer {api_key}",
+                "x-upstage-client": "mcp",
+            }
             
             if ctx:
                 await ctx.report_progress(30, 100)

--- a/src/upstage_mcp/info_extractor.py
+++ b/src/upstage_mcp/info_extractor.py
@@ -141,7 +141,8 @@ async def generate_schema(
     async with httpx.AsyncClient(timeout=httpx.Timeout(REQUEST_TIMEOUT)) as client:
         headers = {
             "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json"
+            "x-upstage-client": "mcp",
+            "Content-Type": "application/json",
         }
         
         # Prepare request data in OpenAI format
@@ -209,7 +210,8 @@ async def extract_with_schema(
     async with httpx.AsyncClient(timeout=httpx.Timeout(REQUEST_TIMEOUT)) as client:
         headers = {
             "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json"
+            "x-upstage-client": "mcp",
+            "Content-Type": "application/json",
         }
         
         # Prepare request data in OpenAI format


### PR DESCRIPTION
## Description:
- API 요청 시 추적용 헤더를 추가하였습니다.
   ```json
   {
     "x-upstage-client" : "mcp"
   }
   ```

## Issue: 
- 로컬에서 테스트가 실패하였습니다. 파라미터 및 버전 문제로 보입니다.
  - `langchain_main.py`의 경우 `ModuleNotFoundError: No module named 'mcp.client.streamable_http`가 발생합니다.
  - `openai_main.py`의 경우 `Gym has been unmaintained since 2022 and does not support NumPy 2.0 amongst other critical functionality.`가 발생합니다.
- 추후 테스트 시 fastMCP 최신 버전의 Client를 사용할 수 있을 것 같습니다. 다만 버전 업데이트가 어떠한 영향을 끼칠 지 확신할 수 없어, 추후 말씀 나눠보고 작업해보고자 합니다.

## Dependencies: N/A